### PR TITLE
Wrap "$pkg_json" in quotes to support spaces in path

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -48,7 +48,7 @@ fi
 pkg_json="$PWD/package.json"
 
 if [[ -f "$pkg_json" ]]; then
-  pkg_json_contents="$(cat $pkg_json)"
+  pkg_json_contents="$(cat "$pkg_json")"
 
   if [[ -z "$node_ver" ]]; then
     node_ver="$(echo $pkg_json_contents | jq -r '.hnvm.node')"


### PR DESCRIPTION
Without quotes, the shell treats spaces as delimiters between different file paths here, which causes failures like https://github.com/apexskier/nova-typescript/issues/128.

For a more detailed explanation, check out https://github.com/koalaman/shellcheck/wiki/SC2086. I'd advise running [shellcheck](https://github.com/koalaman/shellcheck) on this file in general - I noticed a number of other issues. (I'm just fixing this one as example, as I don't use `hnvm` myself.)