### PR TITLE
docs(readme): add note about homebrew tap availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ consistent packages, and upgrades required by one package don't affect another.
 
 ## Installation
 
-### [Homebrew](https://brew.sh)
+### [Homebrew](https://brew.sh) (Compass Employees Only)
 
 HNVM is distributed via [Homebrew](https://brew.sh) inside the
 [`UrbanCompass/versions` tap](https://github.com/UrbanCompass/homebrew-versions):


### PR DESCRIPTION
Not sure how widely used hnvm is outside of Compass but I'd consider moving lower in the installation options if primary audience is external users :)