### PR TITLE
fix: fix typo in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,7 @@ if not_in_path; then
   export PATH="${bin_path}:${PATH}"
 
   # shellcheck source=/dev/null
-  source "${script_dir}/lib/colors.sh"
+  source "${script_dir}/lib/hnvm/colors.sh"
   green "Added local hnvm to PATH:"
   echo "${PATH}"
 fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -29,7 +29,7 @@ if is_in_path; then
   PATH=${PATH#:}; PATH=${PATH%:}
 
   # shellcheck source=/dev/null
-  source "${script_dir}/lib/colors.sh"
+  source "${script_dir}/lib/hnvm/colors.sh"
   green "Removed local hnvm from PATH:"
   echo "${PATH}"
 fi


### PR DESCRIPTION
Minor typo fix to the install/uninstall scripts.

It appears when the folders were renamed in https://github.com/UrbanCompass/hnvm/commit/370ceb10c9deb34a80a0291f6264b699d30c2540 this one got left out.