### PR TITLE
Feat: Support Apple Silicon builds of Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ output, set the `HNVM_QUIET` environment variable to `true` to have this output 
 Location of the NodeJS distribution files. If you provide a custom destination, you should ensure
 that the repository layout mirrors that of nodejs.org:
 ```
-/node-v${node_ver}-${platform}-x64.tar.gz
+/node-v${node_ver}-${platform}-${cpu_arch}.tar.gz
 ```
 
 ### `HNVM_PNPM_REGISTRY` (Defaults to `https://registry.npmjs.org`)

--- a/lib/hnvm/config.sh
+++ b/lib/hnvm/config.sh
@@ -51,6 +51,11 @@ pkg_json="${PWD}/package.json"
 if [[ -f "${pkg_json}" ]]; then
   pkg_json_contents="$(cat "${pkg_json}")"
 
+  echo $pkg_json_contents | jq || {
+    red "An error occurred while parsing package.json"
+    exit 1
+  }
+
   if [[ -z "${node_ver}" ]]; then
     node_ver="$(echo "${pkg_json_contents}" | jq -r '.hnvm.node')"
 

--- a/lib/hnvm/ensure_bin.sh
+++ b/lib/hnvm/ensure_bin.sh
@@ -50,16 +50,23 @@ function download_node() {
     exit 1
   fi
 
+  node_major=$(echo $node_ver | grep -Eo "^\d+")
+  cpu_arch="x64"
+  if [[ "$node_major" -ge 16 ]]; then
+    # Apple Silicon builds exist in Node 16+
+    cpu_arch="$(uname -m)"
+  fi
+
   rm -rf "${node_path}"
   mkdir -p "${node_path}"
 
   blue "Downloading node v${node_ver} to ${HNVM_PATH}/node" > "${COMMAND_OUTPUT}"
 
   if [[ "${HNVM_QUIET}" == "true" ]]; then
-    curl "${HNVM_NODE_DIST}/v${node_ver}/node-v${node_ver}-${platform}-x64.tar.gz" --silent |
+    curl "${HNVM_NODE_DIST}/v${node_ver}/node-v${node_ver}-${platform}-${cpu_arch}.tar.gz" --silent |
       tar xz -C "${node_path}" --strip-components=1 > "${COMMAND_OUTPUT}"
   else
-    curl "${HNVM_NODE_DIST}/v${node_ver}/node-v${node_ver}-${platform}-x64.tar.gz" |
+    curl "${HNVM_NODE_DIST}/v${node_ver}/node-v${node_ver}-${platform}-${cpu_arch}.tar.gz" |
       tar xz -C "${node_path}" --strip-components=1 > "${COMMAND_OUTPUT}"
   fi
 }


### PR DESCRIPTION
Porting over two internal changes:

1. Supporting non-`x64` builds of Node (available with Node 16+), and
2. Emitting a clear error message if `jq` can't parse `package.json`