### PR TITLE
Feat: Support Apple Silicon builds of Node (take 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ output, set the `HNVM_QUIET` environment variable to `true` to have this output 
 Location of the NodeJS distribution files. If you provide a custom destination, you should ensure
 that the repository layout mirrors that of nodejs.org:
 ```
-/node-v${node_ver}-${platform}-x64.tar.gz
+/node-v${node_ver}-${platform}-${cpu_arch}.tar.gz
 ```
 
 ### `HNVM_PNPM_REGISTRY` (Defaults to `https://registry.npmjs.org`)

--- a/lib/hnvm/config.sh
+++ b/lib/hnvm/config.sh
@@ -51,6 +51,11 @@ pkg_json="${PWD}/package.json"
 if [[ -f "${pkg_json}" ]]; then
   pkg_json_contents="$(cat "${pkg_json}")"
 
+   echo $pkg_json_contents | jq > /dev/null || {
+    red "An error occurred while parsing package.json"
+    exit 1
+  }
+
   if [[ -z "${node_ver}" ]]; then
     node_ver="$(echo "${pkg_json_contents}" | jq -r '.hnvm.node')"
 

--- a/lib/hnvm/ensure_bin.sh
+++ b/lib/hnvm/ensure_bin.sh
@@ -50,16 +50,25 @@ function download_node() {
     exit 1
   fi
 
+  cpu_arch="x64"
+  if [[ $(uname -m) == "arm64" ]]; then
+    node_major=$(echo "$node_ver" | grep -Eo "^\d+")
+    if [[ "$node_major" -ge 16 ]]; then
+      cpu_arch="arm64"
+    fi
+  fi
+
   rm -rf "${node_path}"
   mkdir -p "${node_path}"
 
   blue "Downloading node v${node_ver} to ${HNVM_PATH}/node" > "${COMMAND_OUTPUT}"
 
+  node_download_url="${HNVM_NODE_DIST}/v${node_ver}/node-v${node_ver}-${platform}-${cpu_arch}.tar.gz"
   if [[ "${HNVM_QUIET}" == "true" ]]; then
-    curl "${HNVM_NODE_DIST}/v${node_ver}/node-v${node_ver}-${platform}-x64.tar.gz" --silent |
+    curl $node_download_url --silent |
       tar xz -C "${node_path}" --strip-components=1 > "${COMMAND_OUTPUT}"
   else
-    curl "${HNVM_NODE_DIST}/v${node_ver}/node-v${node_ver}-${platform}-x64.tar.gz" |
+    curl $node_download_url |
       tar xz -C "${node_path}" --strip-components=1 > "${COMMAND_OUTPUT}"
   fi
 }


### PR DESCRIPTION
This is second attempt at https://github.com/UrbanCompass/hnvm/pull/25, which was reverted by #26 and #27.

Changes vs. #25:

1. Only attempt to download `x64` and `arm64` builds of Node (not `amd64` or other values that `uname -m` might return that don't correspond to valid Node downloads)
3. Don't emit `package.json` to stdout when checking its validity

My speculation is that the CI failures we saw with the #25 build were caused by `uname -m` returning `amd64`, causing Node to fail to download. However, it's curious to me that no error was emitted in that case. When I try to force an invalid Node download URL on my machine, I get the error

```
tar: Error opening archive: Unrecognized archive format
```

So I can't say that I'm completely sure that this change won't introduce the same CI issue as before. 🤞 