### PR TITLE
patch: Install groovy since nexus orb relies on it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
       # in Nexus itself. This is so "filename" param for publish matches the desired path in Nexus.
       - run: mkdir -p ./hnvm/${CIRCLE_TAG}
       - run: cp ./hnvm.tar.gz ./hnvm/${CIRCLE_TAG}/hnvm.tar.gz
+      - nexus/install
       - nexus/publish:
           username: NEXUS_USERNAME
           password: NEXUS_PASSWORD


### PR DESCRIPTION
[QA: None]

The latest publish failed, because the nexus orb that handles publishing logic relies on groovy, but groovy is not given in the CI image we use for publish jobs. https://app.circleci.com/pipelines/github/UrbanCompass/hnvm/72/workflows/da711d82-c807-4741-8757-9e69a5673d79/jobs/92

I looked more into the orb and I think the `nexus/install` command will handle installing groovy. There's more info and implementation of that step here https://circleci.com/developer/orbs/orb/sonatype/nexus-platform-orb#commands-install