### PR TITLE
patch: Use nexus docker image as the publish job executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,7 @@ jobs:
           command: npm test
           working_directory: ./test
   publish:
-    docker:
-      - image: cimg/base:2020.01
+    executor: nexus/nexus-platform-cli
     working_directory: '~'
     steps:
       - checkout:
@@ -42,7 +41,6 @@ jobs:
       # in Nexus itself. This is so "filename" param for publish matches the desired path in Nexus.
       - run: mkdir -p ./hnvm/${CIRCLE_TAG}
       - run: cp ./hnvm.tar.gz ./hnvm/${CIRCLE_TAG}/hnvm.tar.gz
-      - nexus/install
       - nexus/publish:
           username: NEXUS_USERNAME
           password: NEXUS_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ jobs:
       # in Nexus itself. This is so "filename" param for publish matches the desired path in Nexus.
       - run: mkdir -p ./hnvm/${CIRCLE_TAG}
       - run: cp ./hnvm.tar.gz ./hnvm/${CIRCLE_TAG}/hnvm.tar.gz
+      - nexus/install
       - nexus/publish:
           username: NEXUS_USERNAME
           password: NEXUS_PASSWORD


### PR DESCRIPTION
[QA: None]

The latest publish failed, because although groovy was installed, groovy then depends on java which is not provided in our CI environment.

publish logs https://app.circleci.com/pipelines/github/UrbanCompass/hnvm/75/workflows/b23c07ff-7b04-4573-b2b8-36100a868b1d/jobs/97

I looked at the orb docs and its [github](https://github.com/sonatype-nexus-community/circleci-nexus-orb) again and it makes no mention of Java needing to be provided before using the orb 👎 . However, the nexus orb does provide their own docker image as an executor like this:

```
executors:
  nexus-platform-cli:
    description: "Sonatype image with Nexus Platform CLI"
    docker:
    - image: sonatype/nexus-platform-cli:0.0.20191018-130334.c9f67e0
```

The description is a little vague, but I'm hoping this image of theirs provides any prerequisites like java that they expect. 

---

If this doesn't work out, I think I will just drop the nexus orb entirely and do a raw curl call to push the artifact to nexus.