### PR TITLE
patch: try to use openjdk docker image for publishing, last attempt with the nexus orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,9 @@ jobs:
           command: npm test
           working_directory: ./test
   publish:
-    executor: nexus/nexus-platform-cli
+    # The nexus orb is implemented in groovy, so Java is a hard requirement before using it
+    docker:
+      - image: cimg/openjdk:18.0.1
     working_directory: '~'
     steps:
       - checkout:


### PR DESCRIPTION
[QA: None]

Last attempt to use the nexus orb. Going to try using circle's own openjdk images to provide the Java runtime, instead of the provided executor from the nexus orb.

That executor does provide a java runtime and groovy install, but the executor doesn't have `curl` installed, so running the orb's `install` command fails. I dug around more and found a similar issue:
https://github.com/sonatype-nexus-community/circleci-nexus-orb/issues/21#issuecomment-1190503244

Dug more and found orb demos that also suggest to use the openjdk images:
https://github.com/sonatype-nexus-community-circleci/circleci-nexus-demo/blob/main/.circleci/config.yml