### PR TITLE
patch: Downgrade publish jdk image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,9 @@ jobs:
           working_directory: ./test
   publish:
     # The nexus orb is implemented in groovy, so Java is a hard requirement before using it
+    # Orb@1.0.28 also specifically relies on Java8, so upgrading the image is brittle.
     docker:
-      - image: cimg/openjdk:18.0.1
+      - image: cimg/openjdk:8.0
     working_directory: '~'
     steps:
       - checkout:


### PR DESCRIPTION
[QA: None]

Latest publish attempt: https://app.circleci.com/pipelines/github/UrbanCompass/hnvm/83/workflows/7c60df2c-5f1e-410e-b1d2-8c617506d608/jobs/112

Groovy and Java are at least running and reachable now in the publish job, but it looks like the orb implementation relies on a specific older version of java (Java 8). So we cannot pull in the latest openjdk image as the base image.

I am downgrading the image to jdk 8 to match the demos at https://github.com/sonatype-nexus-community-circleci/circleci-nexus-demo/blob/main/.circleci/config.yml