### PR TITLE
patch: [TECH-6818] separate collected hnvmrc files by newline, so comment lines are properly removed consistently

### DIFF
--- a/lib/hnvm/config.sh
+++ b/lib/hnvm/config.sh
@@ -45,7 +45,10 @@ for i in "${dirs_array[@]}"; do
   fi
 
   if [[ -f "${rc_file}" && "${HNVM_NOFALLBACK}" != "true" ]]; then
-    exports="$(cat "${rc_file}") ${exports}"
+    # The rc file and previous exports should ALWAYS be separated by a newline
+    # otherwise, the grep to weed out comment lines will fail if an hnvmrc starts with an L1 comment
+    newline=$'\n'
+    exports="$(cat "${rc_file}")${newline}${exports}"
     # shellcheck disable=SC2046
     export $(echo "${exports}" | grep -E -v '^#'| sed 's#~#'"${HOME}"'#g' | xargs)
   fi


### PR DESCRIPTION
[QA: None]

Context: https://compass-tech.slack.com/archives/C051C362A8G/p1704397744305439?thread_ts=1704304893.864579&cid=C051C362A8G

---

tl;dr

Consider the following hnvmrc files:
```bash
[joseph.galindo@C02XK68RJG5L appdomain_management (jrg/postinstall-npm)]$ pwd
/Users/joseph.galindo/development/urbancompass/tests/integration/kronos/appdomain_management

[joseph.galindo@C02XK68RJG5L appdomain_management (jrg/postinstall-npm)]$ cat ./.hnvmrc
# core-js postinstall spins up a subprocess that doesn't seem to inherit stdout properly
# this is an issue because hnvm by default will send all output to /dev/stdout
# HNVM_QUIET instead sends all output to /dev/null
# so in CI, `npm i` can break if HNVM_QUIET is not enabled
HNVM_QUIET=true
```

```bash
[joseph.galindo@C02XK68RJG5L urbancompass (jrg/postinstall-npm)]$ pwd
/Users/joseph.galindo/development/urbancompass

[joseph.galindo@C02XK68RJG5L urbancompass (jrg/postinstall-npm)]$ cat ./.hnvmrc
HNVM_NOFALLBACK=true
HNVM_NODE=18.17.1
HNVM_NODE_DIST=https://artifacts.compass-tech.net/repository/nodejs/
HNVM_PNPM_REGISTRY=https://artifacts.compass-tech.net/repository/npm-remote/
```

If you run this command with the current hnvm, you run into an error due to hnvm concatting rc files by whitespace:
```bash
[joseph.galindo@C02XK68RJG5L appdomain_management (jrg/postinstall-npm)]$ node --version
/usr/local/Cellar/hnvm/v0.15.6/lib/hnvm/config.sh: line 54: export: `#': not a valid identifier
/usr/local/Cellar/hnvm/v0.15.6/lib/hnvm/config.sh: line 54: export: `core-js': not a valid identifier
```

To fix this, we need this PR, so the contents are instead joined on a newline. With that in place, the `grep` call will properly remove all the comment lines from processing and NOT attempt to `export` them:
```bash
[joseph.galindo@C02XK68RJG5L appdomain_management (jrg/postinstall-npm)]$ node --version
v18.17.1

```
