### PR TITLE
patch: Change ensure_bin to fail for all bad curl responses

### DIFF
--- a/lib/hnvm/ensure_bin.sh
+++ b/lib/hnvm/ensure_bin.sh
@@ -57,10 +57,10 @@ function download_node() {
 
   node_download_url="${HNVM_NODE_DIST}/v${node_ver}/node-v${node_ver}-${platform}-${cpu_arch}.tar.gz"
   if [[ "${HNVM_QUIET}" == "true" ]]; then
-    curl "$node_download_url" --silent |
+    curl "$node_download_url" --silent --fail |
       tar xz -C "${node_path}" --strip-components=1 >> "${COMMAND_OUTPUT}"
   else
-    curl "$node_download_url" |
+    curl "$node_download_url" --fail |
       tar xz -C "${node_path}" --strip-components=1 >> "${COMMAND_OUTPUT}"
   fi
 }
@@ -72,11 +72,11 @@ function download_pnpm() {
   blue "Downloading pnpm v${pnpm_ver} to ${HNVM_PATH}/pnpm" >> "${COMMAND_OUTPUT}"
 
   if [[ "${HNVM_QUIET}" == "true" ]]; then
-    curl -L https://raw.githubusercontent.com/pnpm/self-installer/master/install.js --silent |
+    curl -L https://raw.githubusercontent.com/pnpm/self-installer/master/install.js --silent --fail |
       PNPM_VERSION=${pnpm_ver} PNPM_DEST=${pnpm_path} PNPM_REGISTRY=${HNVM_PNPM_REGISTRY} ${node_bin} >> \
       "${COMMAND_OUTPUT}"
   else
-    curl -L https://raw.githubusercontent.com/pnpm/self-installer/master/install.js |
+    curl -L https://raw.githubusercontent.com/pnpm/self-installer/master/install.js --fail |
       PNPM_VERSION=${pnpm_ver} PNPM_DEST=${pnpm_path} PNPM_REGISTRY=${HNVM_PNPM_REGISTRY} ${node_bin} >> \
       "${COMMAND_OUTPUT}"
   fi
@@ -89,10 +89,10 @@ function download_yarn() {
   blue "Downloading yarn v${yarn_ver} to ${HNVM_PATH}/yarn" >> "${COMMAND_OUTPUT}"
 
   if [[ "${HNVM_QUIET}" == "true" ]]; then
-    curl -L "${HNVM_YARN_DIST}/${yarn_ver}/yarn-v${yarn_ver}.tar.gz" --silent |
+    curl -L "${HNVM_YARN_DIST}/${yarn_ver}/yarn-v${yarn_ver}.tar.gz" --silent --fail |
       tar xz -C "${yarn_path}" --strip-components=1 >> "${COMMAND_OUTPUT}"
   else
-    curl -L "${HNVM_YARN_DIST}/${yarn_ver}/yarn-v${yarn_ver}.tar.gz" |
+    curl -L "${HNVM_YARN_DIST}/${yarn_ver}/yarn-v${yarn_ver}.tar.gz" --fail |
       tar xz -C "${yarn_path}" --strip-components=1 >> "${COMMAND_OUTPUT}"
   fi
 }


### PR DESCRIPTION
PR is a result of
- [failed circle job](https://app.circleci.com/pipelines/github/UrbanCompass/urbancompass/1213500/workflows/dfc3a880-4d58-4745-ad6c-27b0a96a4e80/jobs/8451797)
- [slack thread](https://compass-tech.slack.com/archives/CAJ50Q91U/p1745956106655729?thread_ts=1745950332.910979&cid=CAJ50Q91U)

The gist of it is, normally, if a command in `ensure_bin` fails, it is supposed to auto fail the whole script right then and there. This is done through the `set -e` config at the top of the script.

However, we make several curl calls in `ensure_bin`
- one for nodejs binary
- one for nodejs binary (silent option)
- one for pnpm installer script
- one for pnpm installer script (silent option)
- one for yarn tarball
- one for yarn tarball (silent option)

In the circle job, we noticed that the curl call for the pnpm installer script failed. But, `ensure_bin` as a whole did not fail, and continued to run as if the curl call was successful. This is because by default, curl will always return exit code 0, even for bad responses like 404s.

Because the curl call returned an exit code 0, the `set -e` config isn't proc'd, and `ensure_bin` runs to the end.

Control then gets handed back to `bin/pnpm`, and only there, does an error finally happen. `bin/pnpm` will run `{node_binary} {pnpm_binary} {pnpm_command}`, and only at this point, the pnpm binary isn't found, and nodejs internals catches it and throws an error.

---

All of this said - ideally, we are catching this error way earlier, when the curl call for the pnpm installer script fails. This PR fixes that by making all those curl calls provide `curl <url> --fail`. Now, if those curl calls get back a non 200 response code, they will fail with exit code 22 or 56, and that will trigger the `set -e` behavior in `ensure_bin` to throw an error immediately.

More docs for `--fail` at https://curl.se/docs/manpage.html