### PR TITLE
feat: Add support for installing/managing bun versions

### DIFF
--- a/.hnvmrc
+++ b/.hnvmrc
@@ -1,3 +1,4 @@
 HNVM_NODE=latest
 HNVM_PNPM=latest
 HNVM_YARN=latest
+HNVM_BUN=latest

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Instead of relying on the version of `node`, `npm`, `pnpm`, etc. each individual
 machine has installed locally, packages use a system we've named HNVM, which stands for Hermetic
 Node Version Manager. Having our `node` binaries be hermetic means each app or package defines what
 version of `node` they depend on. That version is installed and used to run whenever the package
-runs scripts in `node`, `npm`, `pnpm`, and `yarn`. This ensures that everyone's systems output
-consistent packages, and upgrades required by one package don't affect another.
+runs scripts in `node`, `npm`, `pnpm`, `yarn`, and `bun`. This ensures that everyone's systems
+output consistent packages, and upgrades required by one package don't affect another.
 
 ## Installation
 
@@ -51,14 +51,20 @@ node -v # No longer uses hnvm node script
 Note that `hnvm` depends on [`jq`](https://stedolan.github.io/jq/) being available in your global
 `$PATH`. If you don't install hnvm via `brew` or `basher`, you'll have to make sure that `jq` is installed on your own.
 
+Managing `bun` additionally requires `unzip` (bun is distributed as a `.zip` archive). This is
+present by default on macOS and most Linux distributions.
+
 ## Usage
 
-HNVM reads the version of `node`/`pnpm`/`yarn` set in your `package.json` file' `"engines"` field. If
-no version is set, it will default to the current versions set in HNVM's own `package.json`. Unlike
-HNVM 1.0, you don't have to find any particular bash script to run HNVM. Just use the regular
-`node`, `npm`, etc. commands you're used to from anywhere on your computer. If you run it
-next to a `package.json` file, it will read the engines field. If not, it'll default to the global
-version.
+HNVM reads the version of `node`/`pnpm`/`yarn`/`bun` set in your `package.json` file' `"engines"`
+field. If no version is set, it will default to the current versions set in HNVM's own
+`package.json`. Unlike HNVM 1.0, you don't have to find any particular bash script to run HNVM. Just
+use the regular `node`, `npm`, `bun`, etc. commands you're used to from anywhere on your computer. If
+you run it next to a `package.json` file, it will read the engines field. If not, it'll default to
+the global version.
+
+Because `bun` is a standalone native binary, `bun` and `bunx` do not require a hermetic `node` to be
+installed — they run directly.
 
 ```js
 // main.js
@@ -87,6 +93,7 @@ HNVM_PATH=/path/to/.hnvm
 HNVM_NODE=10.0.0
 HNVM_PNPM=3.0.0
 HNVM_YARN=1.19.0
+HNVM_BUN=1.3.14
 ```
 
 The full list of config options are detailed below.
@@ -100,7 +107,8 @@ Versions configured in `package.json` files go in either the `"engines"` field o
   "engines": {
     "node": "10.0.0",
     "pnpm": "3.0.0",
-    "yarn": "1.19.0"
+    "yarn": "1.19.0",
+    "bun": "1.3.14"
   },
   "hnvm": {
     "node": "11.0.0" // This overrules any versions set in "engines"
@@ -131,9 +139,9 @@ node version range, but HNVM itself runs at a specific version:
 Location on disk to download binaries to, defaulting to an `.hnvm` directory in your `$HOME`
 directory.
 
-### `HNVM_NODE`, `HNVM_PNPM`, `HNVM_YARN` (Defaults to `latest`)
+### `HNVM_NODE`, `HNVM_PNPM`, `HNVM_YARN`, `HNVM_BUN` (Defaults to `latest`)
 
-Version of `node`/`pnpm`/`yarn` to use. If semver ranges are provided instead of exact versions
+Version of `node`/`pnpm`/`yarn`/`bun` to use. If semver ranges are provided instead of exact versions
 (e.g. the defaults are set to `latest`), HNVM will perform curl requests to resolve those to an
 exact version. However you'll get a warning about this since it could slow down execution time from
 the async request, or it might even fail to work at all if the curl requests fail to load.
@@ -188,6 +196,21 @@ custom destination, you should ensure the layout mirrors that of `yarnpkg.com`:
 ```
 /${yarn_ver}/yarn-v${yarn_ver}.tar.gz
 ```
+
+### `HNVM_BUN_DIST` (Defaults to `https://github.com/oven-sh/bun/releases/download`)
+
+Location from where to download `bun` from. When providing a custom destination, you should ensure
+the layout mirrors that of bun's GitHub releases:
+```
+/bun-v${bun_ver}/bun-${platform}-${cpu_arch}.zip
+```
+where `platform` is `darwin`/`linux` and `cpu_arch` is `x64`/`aarch64`.
+
+### `HNVM_BUN_VARIANT` (Defaults to '')
+
+Variant of the bun distribution files to fetch. Set to `baseline` for CPUs without AVX2 support, or
+`musl` for musl-based Linux distributions (e.g. Alpine). This is appended to the download filename
+(e.g. `bun-linux-x64-musl.zip`).
 
 
 ### `HNVM_NOFALLBACK` (Defaults to `false`)

--- a/bin/bun
+++ b/bin/bun
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+bun_bin=
+
+# The exposed bin files are symlinked into the user's $PATH, so we need to make our way back to
+# the original path location to understand where the rest of this package's files are installed
+source="${BASH_SOURCE[0]}"
+while [ -h "$source" ]; do # resolve $source until the file is no longer a symlink
+  script_dir="$( cd -P "$( dirname "$source" )" >/dev/null 2>&1 && pwd )"
+  source="$(readlink "$source")"
+  [[ $source != /* ]] && source="$script_dir/$source"
+done
+script_dir="$( cd -P "$( dirname "$source" )" >/dev/null 2>&1 && pwd )"
+
+# shellcheck source=/dev/null
+source "$script_dir/../lib/hnvm/ensure_bin.sh"
+
+exec "${bun_bin}" "$@"

--- a/bin/bunx
+++ b/bin/bunx
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+bun_bin=
+
+# The exposed bin files are symlinked into the user's $PATH, so we need to make our way back to
+# the original path location to understand where the rest of this package's files are installed
+source="${BASH_SOURCE[0]}"
+while [ -h "$source" ]; do # resolve $source until the file is no longer a symlink
+  script_dir="$( cd -P "$( dirname "$source" )" >/dev/null 2>&1 && pwd )"
+  source="$(readlink "$source")"
+  [[ $source != /* ]] && source="$script_dir/$source"
+done
+script_dir="$( cd -P "$( dirname "$source" )" >/dev/null 2>&1 && pwd )"
+
+# shellcheck source=/dev/null
+source "$script_dir/../lib/hnvm/ensure_bin.sh"
+
+exec "${bun_bin}" x "$@"

--- a/lib/hnvm/config.sh
+++ b/lib/hnvm/config.sh
@@ -209,9 +209,26 @@ function find_local_node() {
     # download_node is only defined once ensure_bin.sh has been sourced. When it's available (e.g. a
     # bun range needs resolving and no node exists yet), bootstrap a node so resolution can proceed.
     if declare -F download_node > /dev/null; then
+      # Guard against infinite recursion: resolving a node range itself calls back into
+      # find_local_node (via resolve_ver). Only attempt the bootstrap once.
+      if [[ "${node_bootstrap_attempted}" == "true" ]]; then
+        red "No local copy of node available and unable to download one for version resolution. Please use hnvm at least once on an exact version, or set HNVM_NODE to an exact version."
+        exit 1
+      fi
+      node_bootstrap_attempted=true
+
       node_ver="${node_ver:-${HNVM_NODE:-latest}}"
-      resolve_ver "node" "${node_ver}"
-      node_ver="${resolve_ver_result}"
+      # download_node requires an exact version. If node_ver is a tag/range we resolve it first, but
+      # that resolution needs node too. Only recurse into resolve_ver when we already have a node to
+      # run it with; otherwise (registry unreachable, no local node) fail cleanly rather than loop.
+      if is_invalid_version "${node_ver}"; then
+        resolve_ver "node" "${node_ver}"
+        node_ver="${resolve_ver_result}"
+      fi
+      if is_invalid_version "${node_ver}"; then
+        red "Unable to resolve node version '${node_ver}' to bootstrap version resolution. Set HNVM_NODE to an exact version, or use hnvm once while the registry is reachable."
+        exit 1
+      fi
       export node_path="${HNVM_PATH}/node/${node_ver}"
       export node_bin="${node_path}/bin/node"
       download_node

--- a/lib/hnvm/config.sh
+++ b/lib/hnvm/config.sh
@@ -54,12 +54,24 @@ export HNVM_NODE_DIST=${HNVM_NODE_DIST:-'https://nodejs.org/dist'}
 export HNVM_NODE_VARIANT=${HNVM_NODE_VARIANT:-''}
 export HNVM_PNPM_REGISTRY=${HNVM_PNPM_REGISTRY:-'https://registry.npmjs.org'}
 export HNVM_YARN_DIST=${HNVM_YARN_DIST:-'https://yarnpkg.com/downloads'}
+export HNVM_BUN_DIST=${HNVM_BUN_DIST:-'https://github.com/oven-sh/bun/releases/download'}
+export HNVM_BUN_VARIANT=${HNVM_BUN_VARIANT:-''}
 export HNVM_SKIP_URL_VALIDATION=${HNVM_SKIP_URL_VALIDATION:-false}
+
+# Whether this invocation is a bun/bunx command. Match on the basename of $0 (not the full path)
+# so directories that happen to contain "bun" don't get misdetected.
+invocation_name="$(basename "${0}")"
+is_bun=false
+if [[ "${invocation_name}" == "bun" || "${invocation_name}" == "bunx" ]]; then
+  is_bun=true
+fi
+export is_bun
 
 # Read env vars set in profile or at runtime
 export node_ver="${HNVM_NODE}"
 export pnpm_ver="${HNVM_PNPM}"
 export yarn_ver="${HNVM_YARN}"
+export bun_ver="${HNVM_BUN}"
 
 available_node_bin=
 
@@ -130,6 +142,14 @@ if [[ -f "${pkg_json}" ]]; then
       yarn_ver="$(echo "${pkg_json_contents}" | jq -r '.engines.yarn')"
     fi
   fi
+
+  if [[ -z "${bun_ver}" ]]; then
+    bun_ver="$(echo "${pkg_json_contents}" | jq -r '.hnvm.bun')"
+
+    if [[ "${bun_ver}" == "null" ]]; then
+      bun_ver="$(echo "${pkg_json_contents}" | jq -r '.engines.bun')"
+    fi
+  fi
 fi
 
 # Fall back to env var
@@ -145,6 +165,10 @@ if [[ -z "${yarn_ver}" || "${yarn_ver}" == "null" ]]; then
   yarn_ver=${HNVM_YARN};
 fi
 
+if [[ -z "${bun_ver}" || "${bun_ver}" == "null" ]]; then
+  bun_ver=${HNVM_BUN};
+fi
+
 # No fallback version(s) could be determined, error out for those missing
 if [[ -z "${pnpm_ver}" && ("${0}" == *pnpm || "${0}" == *pnpx) ]]; then
   error "No HNVM_PNPM version set. Please set a pnpm version."
@@ -156,7 +180,14 @@ if [[ -z "${yarn_ver}" && "${0}" == *yarn ]]; then
   exit 1
 fi
 
-if [[ -z "${node_ver}" ]]; then
+if [[ -z "${bun_ver}" && "${is_bun}" == "true" ]]; then
+  error "No HNVM_BUN version set. Please set a bun version."
+  exit 1
+fi
+
+# bun ships as a standalone native binary and does not require node, so only enforce a node
+# version for invocations that actually run through node (node/npm/npx/pnpm/pnpx/yarn).
+if [[ -z "${node_ver}" && "${is_bun}" != "true" ]]; then
   error "No HNVM_NODE version set. Please set a Node version."
   exit 1
 fi
@@ -166,12 +197,29 @@ function is_invalid_version() {
 }
 
 # Finds _any_ locally available copy of node and sets `available_node_bin` to its path.
+#
+# Node is needed to run find-matching-version.js when resolving a semver range. bun invocations
+# normally skip node entirely, but resolving a bun range still needs a JS runtime; in that case we
+# transparently download node (via download_node, defined in ensure_bin.sh) purely for resolution.
 function find_local_node() {
   local available_node_ver=
-  available_node_ver="$(find "$HNVM_PATH/node/"* | head -n 1)"
+  available_node_ver="$(find "$HNVM_PATH/node/"* 2>/dev/null | head -n 1)"
+
   if [ -z "$available_node_ver" ]; then
-    red "No local copy of node available. Please use hnvm at least once on a specific version before attempting semver ranges."
-    exit 1
+    # download_node is only defined once ensure_bin.sh has been sourced. When it's available (e.g. a
+    # bun range needs resolving and no node exists yet), bootstrap a node so resolution can proceed.
+    if declare -F download_node > /dev/null; then
+      node_ver="${node_ver:-${HNVM_NODE:-latest}}"
+      resolve_ver "node" "${node_ver}"
+      node_ver="${resolve_ver_result}"
+      export node_path="${HNVM_PATH}/node/${node_ver}"
+      export node_bin="${node_path}/bin/node"
+      download_node
+      available_node_ver="${node_path}"
+    else
+      red "No local copy of node available. Please use hnvm at least once on a specific version before attempting semver ranges."
+      exit 1
+    fi
   fi
 
   available_node_bin="${available_node_ver}/bin/node"
@@ -250,8 +298,11 @@ EOF
   resolve_ver_result=${ver}
 }
 
-resolve_ver "node" "${node_ver}"
-node_ver=${resolve_ver_result}
+# bun does not run through node, so skip node resolution/download for bun invocations.
+if [[ "${is_bun}" != "true" ]]; then
+  resolve_ver "node" "${node_ver}"
+  node_ver=${resolve_ver_result}
+fi
 
 if [[ "${0}" == *pnpm || "${0}" == *pnpx ]]; then
   resolve_ver "pnpm" "${pnpm_ver}"
@@ -262,3 +313,7 @@ if [[ "${0}" == *yarn ]]; then
   resolve_ver "yarn" "${yarn_ver}"
   yarn_ver=${resolve_ver_result}
 fi
+
+# bun version resolution happens in ensure_bin.sh instead of here: resolving a bun semver range may
+# need to bootstrap a node via download_node (for find-matching-version.js), which is only defined
+# once ensure_bin.sh has been sourced.

--- a/lib/hnvm/ensure_bin.sh
+++ b/lib/hnvm/ensure_bin.sh
@@ -54,6 +54,10 @@ function validate_url() {
       error "Note: You are using HNVM_NODE_VARIANT='${HNVM_NODE_VARIANT}'"
       error "This variant may not be available for the requested version/platform."
     fi
+    if [[ -n "${HNVM_BUN_VARIANT}" ]]; then
+      error "Note: You are using HNVM_BUN_VARIANT='${HNVM_BUN_VARIANT}'"
+      error "This variant may not be available for the requested version/platform."
+    fi
     return 1
   fi
 }

--- a/lib/hnvm/ensure_bin.sh
+++ b/lib/hnvm/ensure_bin.sh
@@ -13,6 +13,10 @@ script_dir="$( cd -P "$( dirname "${source}" )" >/dev/null 2>&1 && pwd )"
 node_ver=
 pnpm_ver=
 yarn_ver=
+bun_ver=
+# Set by config.sh (sourced below) based on the invocation name; declared here so shellcheck can
+# see it is assigned before use.
+is_bun=false
 
 # shellcheck source=/dev/null
 source "${script_dir}/colors.sh"
@@ -30,6 +34,9 @@ export pnpx_bin="${pnpm_path}/bin/pnpx.js"
 
 export yarn_path="${HNVM_PATH}/yarn/${yarn_ver}"
 export yarn_bin="${yarn_path}/bin/yarn.js"
+
+# NOTE: bun_ver may still be an unresolved semver range at this point. bun_path/bun_bin are set
+# after bun_ver is resolved, further down (resolution can require download_node, defined below).
 
 function validate_url() {
   local url="$1"
@@ -130,6 +137,60 @@ function download_yarn() {
   fi
 }
 
+function download_bun() {
+  platform=
+  if [[ "${OSTYPE}" == "linux-"* ]]; then
+    platform="linux"
+  elif [[ "${OSTYPE}" == "darwin"* ]]; then
+    platform="darwin"
+  else
+    error "OS Platform not supported"
+    exit 1
+  fi
+
+  # bun uses "aarch64" (not node's "arm64") for its ARM builds
+  cpu_arch="x64"
+  if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
+    cpu_arch="aarch64"
+  fi
+
+  variant=""
+  if [[ -n "${HNVM_BUN_VARIANT}" ]]; then
+    # prefix variant with '-' (e.g. "baseline" for older CPUs, "musl" for Alpine)
+    variant="-${HNVM_BUN_VARIANT}"
+  fi
+
+  # e.g. bun-darwin-aarch64, bun-linux-x64-musl
+  bun_target="bun-${platform}-${cpu_arch}${variant}"
+  bun_download_url="${HNVM_BUN_DIST}/bun-v${bun_ver}/${bun_target}.zip"
+
+  # Validate URL before attempting download
+  if ! validate_url "$bun_download_url"; then
+    exit 1
+  fi
+
+  rm -rf "${bun_path}"
+  mkdir -p "${bun_path}/bin"
+
+  blue "Downloading bun v${bun_ver} to ${HNVM_PATH}/bun" | write_to_hnvm_output
+
+  # bun ships a .zip (not a .tar.gz stream), so download to a temp file then unzip
+  bun_zip="${bun_path}/${bun_target}.zip"
+
+  if [[ "${HNVM_QUIET}" == "true" ]]; then
+    curl -L "$bun_download_url" --silent --fail --output "${bun_zip}" | write_to_hnvm_output
+    unzip -q -o "${bun_zip}" -d "${bun_path}" | write_to_hnvm_output
+  else
+    curl -L "$bun_download_url" --fail --output "${bun_zip}" | write_to_hnvm_output
+    unzip -o "${bun_zip}" -d "${bun_path}" | write_to_hnvm_output
+  fi
+
+  # The zip extracts to a folder named after the target with the bun binary inside it
+  mv "${bun_path}/${bun_target}/bun" "${bun_bin}"
+  chmod +x "${bun_bin}"
+  rm -rf "${bun_zip}" "${bun_path:?}/${bun_target}"
+}
+
 # Something's globally installing pnpm and pnpx, need to remove otherwise npm scripts won't use
 # hnvm and they'll use this globally installed one instead
 if [[ -f "${node_path}/bin/pnpm" ]]; then
@@ -151,7 +212,8 @@ if [ -f "${pnpm_path}/bin/pnpx.cjs" ]; then
   pnpx_bin="${pnpm_path}/bin/pnpx.cjs"
 fi
 
-if [[ ! -x "${node_bin}" ]]; then
+# bun does not run through node, so skip the node download for bun invocations.
+if [[ "${is_bun}" != "true" ]] && [[ ! -x "${node_bin}" ]]; then
   download_node
 fi
 
@@ -159,8 +221,24 @@ if [[ "${0}" == *pnpm || "${0}" == *pnpx ]] && [[ ! -f "${pnpm_bin}" || "$("${no
   download_pnpm
 fi
 
-if [[ "${0}" == *yarn ]] && [[ ! -f "${yarn_bin} " || "$("${node_bin}" "${yarn_bin}" -v)" != "${yarn_ver}" ]]; then
+if [[ "${0}" == *yarn ]] && [[ ! -f "${yarn_bin}" || "$("${node_bin}" "${yarn_bin}" -v)" != "${yarn_ver}" ]]; then
   download_yarn
+fi
+
+# Resolve the bun version here (not in config.sh) because a semver range may need download_node to
+# run find-matching-version.js. resolve_ver + find_local_node are defined in config.sh.
+if [[ "${is_bun}" == "true" ]]; then
+  resolve_ver "bun" "${bun_ver}"
+  # resolve_ver_result is set by resolve_ver (defined in config.sh, sourced above)
+  # shellcheck disable=SC2154
+  bun_ver="${resolve_ver_result}"
+
+  export bun_path="${HNVM_PATH}/bun/${bun_ver}"
+  export bun_bin="${bun_path}/bin/bun"
+
+  if [[ ! -x "${bun_bin}" || "$("${bun_bin}" --version 2>/dev/null)" != "${bun_ver}" ]]; then
+    download_bun
+  fi
 fi
 
 # pnpm 6+ uses .cjs files for its bins
@@ -172,4 +250,8 @@ if [ -f "${pnpm_path}/bin/pnpx.cjs" ]; then
   pnpx_bin="${pnpm_path}/bin/pnpx.cjs"
 fi
 
-blue "Using Hermetic NodeJS v${node_ver}" | write_to_hnvm_output
+if [[ "${is_bun}" == "true" ]]; then
+  blue "Using Hermetic bun v${bun_ver}" | write_to_hnvm_output
+else
+  blue "Using Hermetic NodeJS v${node_ver}" | write_to_hnvm_output
+fi

--- a/test/bun-fixed-version.test.js
+++ b/test/bun-fixed-version.test.js
@@ -3,7 +3,7 @@ const {createTestContext} = require('./utils.js')
 
 jest.setTimeout(60_000)
 
-describe('bun with a fixed verison', () => {
+describe('bun with a fixed version', () => {
   const VERSION = '1.3.14'
   let context
 

--- a/test/bun-fixed-version.test.js
+++ b/test/bun-fixed-version.test.js
@@ -1,0 +1,37 @@
+const fs = require('fs')
+const {createTestContext} = require('./utils.js')
+
+jest.setTimeout(60_000)
+
+describe('bun with a fixed verison', () => {
+  const VERSION = '1.3.14'
+  let context
+
+  beforeAll(() => {
+    context = createTestContext()
+    context.createPackageJson({engines: {bun: VERSION}})
+  })
+
+  afterAll(() => {
+    context.cleanup()
+  })
+
+  it('should run without an error exit code', () => {
+    const result = context.execFileSync(context.binaries.bun, ['--eval', 'console.log("Hello, World!")'])
+    expect(result).toContain('Hello, World!')
+  })
+
+  it('should have downloaded the correct version', () => {
+    const files = fs.readdirSync(context.hnvmDir + '/bun')
+    expect(files).toContain(VERSION)
+  })
+
+  it('should use the correct version when attempting to run bun', () => {
+    const result = context.execFileSync(context.binaries.bun, ['--version'])
+    expect(result).toContain(VERSION)
+  })
+
+  it('should not download node for a bun invocation', () => {
+    expect(fs.existsSync(context.hnvmDir + '/node')).toBe(false)
+  })
+})

--- a/test/bun-latest-tag.test.js
+++ b/test/bun-latest-tag.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs')
+const {createTestContext} = require('./utils.js')
+
+jest.setTimeout(60_000)
+
+describe('bun with a tag (latest)', () => {
+  const VERSION = 'latest'
+  let context
+
+  beforeAll(() => {
+    context = createTestContext()
+    context.createPackageJson({engines: {bun: VERSION}})
+  })
+
+  afterAll(() => {
+    context.cleanup()
+  })
+
+  it('should run without an error exit code', () => {
+    const result = context.execFileSync(context.binaries.bun, ['--eval', 'console.log("Hello, World!")'])
+    expect(result).toContain('Hello, World!')
+  })
+
+  it('should have downloaded a version of bun', () => {
+    const files = fs.readdirSync(context.hnvmDir + '/bun')
+    expect(files).toHaveLength(1)
+    expect(files[0]).toMatch(/\d+\.\d+\.\d+/)
+  })
+
+  it('should run bun successfully', () => {
+    context.execFileSync(context.binaries.bun, ['--version'])
+  })
+})

--- a/test/bun-semver-range.test.js
+++ b/test/bun-semver-range.test.js
@@ -1,0 +1,31 @@
+const fs = require('fs')
+const {createTestContext} = require('./utils.js')
+
+jest.setTimeout(60_000)
+
+describe('bun with a semver range', () => {
+  const RANGE = '^1'
+  let context
+
+  beforeAll(() => {
+    context = createTestContext()
+    context.createPackageJson({engines: {bun: RANGE}})
+  })
+
+  afterAll(() => {
+    context.cleanup()
+  })
+
+  it('should resolve the range and download a matching version', () => {
+    context.execFileSync(context.binaries.bun, ['--version'])
+
+    const files = fs.readdirSync(context.hnvmDir + '/bun')
+    expect(files).toHaveLength(1)
+    expect(files[0]).toMatch(/^1\.\d+\.\d+$/)
+  })
+
+  it('should run bun successfully', () => {
+    const result = context.execFileSync(context.binaries.bun, ['--eval', 'console.log("Hello, World!")'])
+    expect(result).toContain('Hello, World!')
+  })
+})

--- a/test/bun-url-validation.test.js
+++ b/test/bun-url-validation.test.js
@@ -1,0 +1,53 @@
+const childProcess = require('child_process')
+const {createTestContext} = require('./utils.js')
+
+jest.setTimeout(60_000)
+
+describe('bun URL validation', () => {
+  it('should provide a clear error message for an invalid bun version', () => {
+    const invalidVersion = '999.999.999'
+    const context = createTestContext()
+    context.createPackageJson({engines: {bun: invalidVersion}})
+
+    try {
+      const result = childProcess.spawnSync(context.binaries.bun, ['--version'], {
+        encoding: 'utf-8',
+        env: {
+          HNVM_PATH: context.hnvmDir,
+          PATH: process.env.PATH,
+        },
+        cwd: context.cwdDir,
+      })
+
+      expect(result.status).not.toBe(0)
+      expect(result.stderr).toContain('URL validation failed')
+      expect(result.stderr).toContain('The requested package/version may not exist')
+    } finally {
+      context.cleanup()
+    }
+  })
+
+  it('should fail when an invalid variant is requested', () => {
+    const VERSION = '1.3.14'
+    const nonExistentVariant = 'invalid-variant-xyz'
+    const context = createTestContext()
+    context.createPackageJson({engines: {bun: VERSION}})
+
+    try {
+      const result = childProcess.spawnSync(context.binaries.bun, ['--version'], {
+        encoding: 'utf-8',
+        env: {
+          HNVM_PATH: context.hnvmDir,
+          HNVM_BUN_VARIANT: nonExistentVariant,
+          PATH: process.env.PATH,
+        },
+        cwd: context.cwdDir,
+      })
+
+      expect(result.status).not.toBe(0)
+      expect(result.stderr).toContain('URL validation failed')
+    } finally {
+      context.cleanup()
+    }
+  })
+})

--- a/test/bun-url-validation.test.js
+++ b/test/bun-url-validation.test.js
@@ -46,6 +46,7 @@ describe('bun URL validation', () => {
 
       expect(result.status).not.toBe(0)
       expect(result.stderr).toContain('URL validation failed')
+      expect(result.stderr).toContain(`HNVM_BUN_VARIANT='${nonExistentVariant}'`)
     } finally {
       context.cleanup()
     }

--- a/test/utils.js
+++ b/test/utils.js
@@ -59,6 +59,8 @@ function createTestContext() {
       node: path.join(hnvmBinDir, 'node'),
       npm: path.join(hnvmBinDir, 'npm'),
       pnpm: path.join(hnvmBinDir, 'pnpm'),
+      bun: path.join(hnvmBinDir, 'bun'),
+      bunx: path.join(hnvmBinDir, 'bunx'),
     },
     createPackageJson(json) {
       fs.writeFileSync(path.join(cwdDir, 'package.json'), JSON.stringify(json))


### PR DESCRIPTION
## What

Adds [bun](https://bun.com/) as a first-class hnvm-managed tool alongside `node`, `pnpm`, and `yarn`. `bun` and `bunx` now get the same hermetic, per-project version pinning hnvm already provides for the other tools.

## Why

Teams increasingly use bun as a runtime and package manager and want the same hermetic behavior (version pinned via `.hnvmrc` / `package.json`, auto-downloaded and cached per version) that hnvm gives node/pnpm/yarn.

## What changed

- **New shims**: `bin/bun` and `bin/bunx` (`bunx` execs `bun x`).
- **Version resolution** (`lib/hnvm/config.sh`): reads `HNVM_BUN` from `package.json` (`hnvm.bun` → `engines.bun`), `.hnvmrc`, and env, reusing the existing `resolve_ver` + `find-matching-version.js` pipeline. `bun` is a valid npm package, so range/tag resolution works unchanged.
- **Download** (`lib/hnvm/ensure_bin.sh`): `download_bun()` modeled on `download_yarn`, adapted for bun's distribution — a `.zip` archive (uses `unzip`, not `tar`), `aarch64` arch naming (vs node's `arm64`), and the existing `validate_url` pre-flight check.
- **Config**: `HNVM_BUN_DIST` (defaults to bun's GitHub releases) and `HNVM_BUN_VARIANT` (`baseline` for older CPUs, `musl` for Alpine — mirrors `HNVM_NODE_VARIANT`).
- **Docs**: README config options, the `unzip` dependency note, and `bun`/`bunx` usage. `.hnvmrc` ships `HNVM_BUN=latest`.
- **Tests**: `bun-fixed-version`, `bun-latest-tag`, `bun-semver-range`, `bun-url-validation`; `bun`/`bunx` added to `test/utils.js`.

## Design notes for reviewers

- **bun does not require node.** It ships as a standalone native binary, so `bun`/`bunx` skip the node resolve+download entirely and exec the binary directly (no `node <bin>` indirection like pnpm/yarn use).
- **Semver ranges bootstrap node for resolution only.** Resolving a bare range (e.g. `^1`) uses `find-matching-version.js`, which needs a JS runtime; when no node is present hnvm transparently downloads one purely for resolution. Exact versions (`1.3.14`) and dist-tags (`latest`, `canary`) resolve via the npm registry and need no node.
- **Invocation detection uses the basename of `$0`** (an `is_bun` flag), not a `*bun*` glob against the full path — a path glob would misfire on any directory containing "bun".

## Incidental fix

Fixes a latent trailing-space bug in the yarn download trigger (`"${yarn_bin} "` → `"${yarn_bin}"`), touched while adding the adjacent bun trigger.

## Testing

- `shellcheck` clean on `bin/bun`, `bin/bunx`, `lib/hnvm/config.sh`, `lib/hnvm/ensure_bin.sh`.
- Full jest suite green (45 tests / 11 suites), including all pre-existing node/yarn/pnpm suites — no regressions.
- Manual smoke tests: fixed-version install, cache reuse (no re-download), `latest` + semver-range resolution (with node bootstrap), `bunx`, bad-version failure via `validate_url`, and `package.json` `engines.bun` resolution.

> ⚠️ Note: the test suite hits live registries and downloads real binaries (same caveat as the existing node tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)